### PR TITLE
[FIX] error[E0277]: `[(&str, &str); 7]` is not an iterator

### DIFF
--- a/src/report_gen.rs
+++ b/src/report_gen.rs
@@ -147,7 +147,7 @@ fn generate_help(o: &mut String) {
 
     w!(o, 4, "<p>Legend</p>");
     w!(o, 4, "<ul>");
-    for (class, desc) in legend_items {
+    for (class, desc) in &legend_items {
         w!(o, 5, "<li><span class='legend_rect {}'></span>{}</li>", class, desc);
     }
     w!(o, 4, "</ul>");


### PR DESCRIPTION
```
src/report_gen.rs:150:26
    |
150 |     for (class, desc) in legend_items {
    |                          ^^^^^^^^^^^^ borrow the array with `&` or call `.iter()` on it to iterate over it
    |
    = help: the trait `std::iter::Iterator` is not implemented for `[(&str, &str); 7]`
    = note: arrays are not iterators, but slices like the following are: `&[1, 2, 3]`
    = note: required by `std::iter::IntoIterator::into_iter`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0277`.
```